### PR TITLE
Add support for RSS and JSON feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ These environment variables are:
 - `CN_EMAIL` - The email address you are using for Collected Notes.
 - `CN_SITE_PATH` - The path of your site in Collected Notes (e.g. for https://collectednotes.com/blog use `blog`).
 
+Optionally, you can add the `FEED_HOME_PAGE_URL` environment variable to enable an RSS and JSON feed to work.
+
 ---
 
 ## Customize your static website

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^16.9.8",
     "autoprefixer": "^9.8.6",
     "clsx": "^1.1.1",
-    "collected-notes": "^2.1.0",
+    "collected-notes": "^2.3.0",
     "date-fns": "^2.15.0",
     "next": "^9.5.2",
     "postcss-nested": "^4.2.3",

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -4,7 +4,22 @@ export default class CNDocument extends Document {
   render() {
     return (
       <Html>
-        <Head />
+        <Head>
+          {process.env.FEED_HOME_PAGE_URL && (
+            <link
+              rel="alternate"
+              type="application/feed+json"
+              href="/api/feed?format=json"
+            />
+          )}
+          {process.env.FEED_HOME_PAGE_URL && (
+            <link
+              rel="alternate"
+              type="application/rss+xml"
+              href="/api/feed?format=xml"
+            />
+          )}
+        </Head>
         <body>
           <script src="dark-mode.js" />
           <Main />

--- a/src/pages/api/feed.ts
+++ b/src/pages/api/feed.ts
@@ -1,0 +1,49 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { collectedNotes } from "collected-notes";
+
+const cn = collectedNotes(process.env.CN_EMAIL, process.env.CN_TOKEN);
+const { FEED_HOME_PAGE_URL } = process.env;
+
+export default async function search(
+  req: NextApiRequest,
+  res: NextApiResponse<string | { message: string }>
+) {
+  if (!FEED_HOME_PAGE_URL) {
+    return res.json({
+      message: "Missing the FEED_HOME_PAGE_URL environment variable.",
+    });
+  }
+
+  if (req.query.format === "json") {
+    const feed = await cn.feed(
+      process.env.CN_SITE_PATH,
+      "public_site",
+      {
+        home_page_url: process.env.FEED_HOME_PAGE_URL,
+        feed_url: new URL(
+          "/feed/api?format=json",
+          process.env.FEED_HOME_PAGE_URL
+        ).toString(),
+      },
+      "json"
+    );
+    res.setHeader("Content-Type", "application/feed+json");
+    return res.send(JSON.stringify(feed, null, 2));
+  }
+
+  const feed = await cn.feed(
+    process.env.CN_SITE_PATH,
+    "public_site",
+    {
+      home_page_url: process.env.FEED_HOME_PAGE_URL,
+      feed_url: new URL(
+        "/feed/api?format=xml",
+        process.env.FEED_HOME_PAGE_URL
+      ).toString(),
+    },
+    "xml"
+  );
+
+  res.setHeader("Content-Type", "application/rss+xml");
+  res.send(feed);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,10 +1951,10 @@ clsx@^1.1.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
-collected-notes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/collected-notes/-/collected-notes-2.1.0.tgz#52e1cc00b59a3f1db04cd439d08603450ab62bab"
-  integrity sha512-oO7Ep+mikT8WeSHqazL+9P6VHB97OuEX6EFMDKwlki2xVjhsL/13vGcznB8hwMzgsrvO0JfoiyLH0K0UT244ng==
+collected-notes@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/collected-notes/-/collected-notes-2.3.0.tgz#660b983dfb05318e2e25b2299770736b2b072825"
+  integrity sha512-ikQYLmJkfqPxHXKEJFdbSXF+VObZJEI5yr021YyYltc0YWalXMIeqFHy3PriwiiiIS1omy/mrQjtuSyyNfjNSQ==
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds an `/api/feed` endpoint to get an RSS or JSON feed, you can request the json version (which is less common) adding `?format=json` to the URL.

The feeds require a new env variable `FEED_HOME_PAGE_URL`, if the variable is not defined, accessing the endpoint will always return a JSON with the message `Missing the FEED_HOME_PAGE_URL environment variable.`. Also in the HTML of the pages the link tags for both feeds will not be added.

If the environment variable is defined, the endpoint will return with the RSS or JSON feed and the link tags for both feeds will be added to the HTML on each request.